### PR TITLE
Misbehaves

### DIFF
--- a/src/chumak_peer.erl
+++ b/src/chumak_peer.erl
@@ -107,7 +107,7 @@ incoming_queue_out(PeerPid) ->
     try 
         gen_server:call(PeerPid, incoming_queue_out)
     catch 
-        _Error:_Info -> empty
+        _Error:Info -> {error,Info}
     end.
 
 %% @doc used to force a peer reconnection, only used for tests

--- a/src/chumak_peer.erl
+++ b/src/chumak_peer.erl
@@ -107,7 +107,7 @@ incoming_queue_out(PeerPid) ->
     try 
         gen_server:call(PeerPid, incoming_queue_out)
     catch 
-        _Error:_Info -> ok
+        _Error:_Info -> empty
     end.
 
 %% @doc used to force a peer reconnection, only used for tests

--- a/src/chumak_rep.erl
+++ b/src/chumak_rep.erl
@@ -124,6 +124,9 @@ recv_from_peer(PeerPid) ->
         {out, Messages} ->
             decode_messages(Messages);
         empty ->
+            empty;
+        {error,Info}->
+            error_logger:info_msg("can't get message out in ~p with reason: ~p~n",[chumak_rep,Info]),
             empty
     end.
 

--- a/src/chumak_router.erl
+++ b/src/chumak_router.erl
@@ -82,21 +82,23 @@ peer_recv_message(State, _Message, _From) ->
      %% This function will never called, because use incoming_queue property
     {noreply, State}.
 
-queue_ready(#chumak_router{recv_queue=RecvQueue, pending_recv=nil}=State, Identity, PeerPid) ->
-    MultiPart = recv_message(Identity, PeerPid),
-    NewRecvQueue = queue:in(MultiPart, RecvQueue),
-    {noreply, State#chumak_router{recv_queue=NewRecvQueue}};
-
-queue_ready(#chumak_router{pending_recv={from, PendingRecv}}=State, Identity, PeerPid) ->
-    MultiPart = recv_message(Identity, PeerPid),
-    gen_server:reply(PendingRecv, {ok, MultiPart}), %% if there is a waiter reply directly
-    {noreply, State#chumak_router{pending_recv=nil}}.
+queue_ready(State, Identity, PeerPid) ->
+    case chumak_peer:incoming_queue_out(PeerPid) of
+        {out, Multipart} ->
+            IdentityBin = list_to_binary(Identity),
+            {noreply,recv_message(State,[IdentityBin | Multipart])};
+        empty ->
+            {noreply,State}
+    end.
 
 peer_disconected(#chumak_router{lbs=LBs}=State, PeerPid) ->
     NewLBs = chumak_lbs:delete(LBs, PeerPid),
     {noreply, State#chumak_router{lbs=NewLBs}}.
 
-recv_message(Identity, PeerPid) ->
-    IdentityBin = list_to_binary(Identity),
-    {out, Multipart} = chumak_peer:incoming_queue_out(PeerPid),
-    [IdentityBin | Multipart].
+recv_message(#chumak_router{recv_queue=RecvQueue, pending_recv=nil}=State,Data)->
+    NewRecvQueue = queue:in(MultiPart, RecvQueue),
+    State#chumak_router{recv_queue=NewRecvQueue};
+
+recv_message(#chumak_router{pending_recv={from, PendingRecv}}=State, Data)->
+    gen_server:reply(PendingRecv, {ok, Data}), %% if there is a waiter reply directly
+    State#chumak_router{pending_recv=nil}.

--- a/src/chumak_socket.erl
+++ b/src/chumak_socket.erl
@@ -106,11 +106,7 @@ handle_info({peer_recv_message, Message, From}, State) ->
 
 handle_info({queue_ready, Identity, From}, State) ->
     queue_ready(Identity, From, State);
-%% In server mode the socket should not exit when a peer shutdown except pair mode ?
-%% Please consider it.
-%handle_info({'EXIT', PeerPid, {shutdown, _Reason}}, State) ->
-%    exit_peer(PeerPid, State),
-%    {stop, normal, State};
+
 %% When the client is crashed we should not exit 
 %% and we should let the implementaion of type to deal with this
 handle_info({'EXIT', PeerPid, _Other}, State) ->

--- a/src/chumak_socket.erl
+++ b/src/chumak_socket.erl
@@ -106,10 +106,11 @@ handle_info({peer_recv_message, Message, From}, State) ->
 
 handle_info({queue_ready, Identity, From}, State) ->
     queue_ready(Identity, From, State);
-
-handle_info({'EXIT', PeerPid, {shutdown, _Reason}}, State) ->
-    exit_peer(PeerPid, State),
-    {stop, normal, State};
+%% In server mode the socket should not exit when a peer shutdown except pair mode ?
+%% Please consider it.
+%handle_info({'EXIT', PeerPid, {shutdown, _Reason}}, State) ->
+%    exit_peer(PeerPid, State),
+%    {stop, normal, State};
 %% When the client is crashed we should not exit 
 %% and we should let the implementaion of type to deal with this
 handle_info({'EXIT', PeerPid, _Other}, State) ->


### PR DESCRIPTION
Dear author

I'm still working on the problem which can cause a server crashed when another side exits.
I think here are main reasons:

1. when a `chumak_peer`  exited  which is caused by `tcp_close` will  cause `chumak_socket` to exit.
1. when a `gen_server:call` is made to `chumak_peer`  after it exited will cause the implementations to exit.

So I comment the code blew in `chumak_socket`
```
   %handle_info({'EXIT', PeerPid, {shutdown, _Reason}}, State) -> 
   %    exit_peer(PeerPid, State),
   %    {stop, normal, State};
``` 

Previous patch I pushed still contains bugs. In this push, I distinguish  between error and empty and check the result of `chumak_peer:incoming_queue_out` in implementations.

So every implementations which use `chumak_peer:incoming_queue_out` will contain codes like below.

```
queue_ready(State, _Identity, PeerPid) ->
    case chumak_peer:incoming_queue_out(PeerPid) of
        {out, Multipart} ->
            {noreply,handle_queue_ready(State,Multipart)};
        empty ->
            {noreply,State};
        {error,Info}->
            error_logger:info_msg("can't get message out in ~p with reason: ~p~n",[chumak_sub,Info]),
            {noreply,State}
    end.
```

Thank you very much.

