### PR TITLE
Allowing dealer as a valid peer for another dealer.

### DIFF
--- a/src/chumak_dealer.erl
+++ b/src/chumak_dealer.erl
@@ -25,6 +25,7 @@
 
 valid_peer_type(rep)    -> valid;
 valid_peer_type(router) -> valid;
+valid_peer_type(dealer) -> valid;
 valid_peer_type(_)      -> invalid.
 
 init(Identity) ->


### PR DESCRIPTION
As seen http://zguide.zeromq.org/php:chapter3#The-DEALER-to-DEALER-Combination, dealer-dealer is a valid combination.

The implementation worked fine while communicating the javascript and erlang implementations of the ØMQ dealers.

Closes #29 