### PR TITLE
Add `unblock` behavior to SUB sockets.

### DIFF
--- a/src/chumak.erl
+++ b/src/chumak.erl
@@ -12,6 +12,7 @@
 
 -export([start/2, stop/1]).
 -export([socket/1, socket/2, connect/4, connect/5, bind/4, send/2, recv/1, send_multipart/2, recv_multipart/1,
+         unblock/1,
          set_socket_option/3,
          cancel/2, subscribe/2,
          resource/0, attach_resource/3,
@@ -167,6 +168,13 @@ recv_multipart(SocketPid)
   when is_pid(SocketPid) ->
     gen_server:call(SocketPid, recv_multipart, infinity).
 
+
+%% @doc unblock a socket that is waiting on a message,
+%% return {error, again}
+-spec unblock(SocketPid::pid()) -> ok.
+unblock(SocketPid)
+  when is_pid(SocketPid) ->
+    gen_server:call(SocketPid, unblock).
 
 %% @doc subscribe a topic, only supported in SUB and XSUB patterns.
 -spec subscribe(SocketPid::pid(), Topic::binary()) -> ok.

--- a/src/chumak_pattern.erl
+++ b/src/chumak_pattern.erl
@@ -31,6 +31,8 @@
 -callback queue_ready(State::pattern_state(), Identity::string(), From::pid()) -> Reply::term().
 -callback peer_disconected(State::pattern_state(), PeerPid::pid()) -> Reply::term().
 
+-callback unblock(State::pattern_state(), From::term()) -> ok.
+
 
 %% @doc find matching pattern for a socket type.
 -spec module(SocketType::socket_type()) -> module_name() | {error, invalid_socket_type}.

--- a/src/chumak_socket.erl
+++ b/src/chumak_socket.erl
@@ -65,6 +65,9 @@ handle_call({send_multipart, Multipart}, From, State) ->
 handle_call(recv_multipart, From, State) ->
     recv_multipart(From, State);
 
+handle_call(unblock, From, State) ->
+    unblock(From, State);
+
 handle_call({bind, tcp, Host, Port}, _From, State) ->
     Reply = chumak_bind:start_link(Host, Port), %% start a bind
     {reply, Reply, State};
@@ -184,6 +187,10 @@ send_multipart(Multipart, From, #state{socket=S, socket_state=T}=State) ->
 
 recv_multipart(From, #state{socket=S, socket_state=T}=State) ->
     Reply = S:recv_multipart(T, From), 
+    store(Reply, State).
+
+unblock(From, #state{socket=S, socket_state=T}=State) ->
+    Reply = S:unblock(T, From),
     store(Reply, State).
 
 get_flags(State) ->


### PR DESCRIPTION
There is no way to `recv` a message and then timeout if no messages are received in a certain time span. Since killing the process that is calling `recv` will cause the handle to it to get cleaned up by the library. This PR introduces the `unblock` behavior which causes the server to clear the `pending_recv` PID and send it a `{error, again}` similar to what ZMQ already does here:

http://api.zeromq.org/4-1:zmq-setsockopt#toc29

If you think this design is good I can replicate it to all other sockets implementing `chumak_pattern`.