### PR TITLE
Add unblock behavior to all socket types

### DIFF
--- a/src/chumak_pair.erl
+++ b/src/chumak_pair.erl
@@ -12,6 +12,7 @@
 
 -export([valid_peer_type/1, init/1, peer_flags/1, accept_peer/2, peer_ready/3,
          send/3, recv/2,
+         unblock/2,
          send_multipart/3, recv_multipart/2, peer_recv_message/3,
          queue_ready/3, peer_disconected/2, identity/1
         ]).
@@ -80,6 +81,15 @@ recv(#chumak_pair{pending_recv=nil, pending_recv_multipart=nil}=State, From) ->
 
 recv(State, _From) ->
     {reply, {error, already_pending_recv}, State}.
+
+unblock(#chumak_pair{pending_recv=PendingRecv}=State, _From) when PendingRecv /= nil ->
+    NewState = State#chumak_pair{pending_recv=nil},
+    gen_server:reply(PendingRecv, {error, again}),
+    {reply, ok, NewState};
+
+unblock(#chumak_pair{pending_recv=nil}=State, _From) ->
+    {reply, ok, State}.
+
 
 send_multipart(#chumak_pair{pending_send=nil, pair_pid=nil}=State, Multipart, From) ->
     %% set send await

--- a/src/chumak_pattern.erl
+++ b/src/chumak_pattern.erl
@@ -31,7 +31,7 @@
 -callback queue_ready(State::pattern_state(), Identity::string(), From::pid()) -> Reply::term().
 -callback peer_disconected(State::pattern_state(), PeerPid::pid()) -> Reply::term().
 
--callback unblock(State::pattern_state(), From::term()) -> ok.
+-callback unblock(State::pattern_state(), From::term()) -> Reply::term().
 
 
 %% @doc find matching pattern for a socket type.

--- a/src/chumak_pub.erl
+++ b/src/chumak_pub.erl
@@ -12,6 +12,7 @@
 
 -export([valid_peer_type/1, init/1, init/2, peer_flags/1, accept_peer/2, peer_ready/3,
          send/3, recv/2,
+         unblock/2,
          send_multipart/3, recv_multipart/2, peer_recv_message/3,
          queue_ready/3, peer_disconected/2, peer_subscribe/3, peer_cancel_subscribe/3,
          identity/1
@@ -97,6 +98,14 @@ recv_multipart(#chumak_pub{xpub=true}=State, _From) ->
 
 recv_multipart(State, _From) ->
     {reply, {error, not_use}, State}.
+
+unblock(#chumak_pub{pending_recv={from, PendingRecv}}=State, _From) ->
+    NewState = State#chumak_pub{pending_recv=nil},
+    gen_server:reply(PendingRecv, {error, again}),
+    {reply, ok, NewState};
+
+unblock(#chumak_pub{pending_recv=nil}=State, _From) ->
+    {reply, ok, State}.
 
 peer_recv_message(State, _Message, _From) ->
      %% This function will never called, because use PUB not receive messages

--- a/src/chumak_push.erl
+++ b/src/chumak_push.erl
@@ -12,6 +12,7 @@
 
 -export([valid_peer_type/1, init/1, peer_flags/1, accept_peer/2, peer_ready/3,
          send/3, recv/2,
+         unblock/2,
          send_multipart/3, recv_multipart/2, peer_recv_message/3,
          queue_ready/3, peer_disconected/2, identity/1
         ]).
@@ -59,6 +60,9 @@ send_multipart(#chumak_push{lb=LB}=State, Multipart, From) ->
     end.
 
 recv_multipart(State, _From) ->
+    {reply, {error, not_use}, State}.
+
+unblock(State, _From) ->
     {reply, {error, not_use}, State}.
 
 peer_recv_message(State, _Message, _From) ->

--- a/src/chumak_rep.erl
+++ b/src/chumak_rep.erl
@@ -12,6 +12,7 @@
 
 -export([valid_peer_type/1, init/1, peer_flags/1, accept_peer/2, peer_ready/3,
          send/3, recv/2,
+         unblock/2,
          send_multipart/3, recv_multipart/2, peer_recv_message/3,
          queue_ready/3, peer_disconected/2, identity/1]).
 
@@ -66,6 +67,15 @@ recv(#chumak_rep{state=idle, lb=LB}=State, From) ->
 
 recv(State, _From) ->
     {reply, {error, efsm}, State}.
+
+unblock(#chumak_rep{pending_recv={from, PendingRecv}}=State, _From) ->
+    NewState = State#chumak_rep{pending_recv=nil},
+    gen_server:reply(PendingRecv, {error, again}),
+    {reply, ok, NewState};
+
+unblock(#chumak_rep{pending_recv=nil}=State, _From) ->
+    {reply, ok, State}.
+
 
 send_multipart(State, _Multipart, _From) ->
     {reply, {error, not_implemented_yet}, State}.

--- a/src/chumak_req.erl
+++ b/src/chumak_req.erl
@@ -12,6 +12,7 @@
 
 -export([valid_peer_type/1, init/1, peer_flags/1, accept_peer/2, peer_ready/3,
          send/3, recv/2,
+         unblock/2,
          send_multipart/3, recv_multipart/2, peer_recv_message/3,
          queue_ready/3, peer_disconected/2, identity/1]).
 
@@ -109,6 +110,13 @@ send_multipart(State, _Multipart, _From) ->
 recv_multipart(State, _From) ->
     {reply, {error, not_implemented_yet}, State}.
 
+unblock(#chumak_req{pending_recv={from, PendingRecv}}=State, _From) ->
+    NewState = State#chumak_req{pending_recv=nil},
+    gen_server:reply(PendingRecv, {error, again}),
+    {reply, ok, NewState};
+
+unblock(#chumak_req{pending_recv=nil}=State, _From) ->
+    {reply, ok, State}.
 
 peer_recv_message(#chumak_req{state=wait_reply, last_peer_sent=From}=State, Message, From) ->
     case chumak_protocol:message_data(Message) of

--- a/src/chumak_router.erl
+++ b/src/chumak_router.erl
@@ -12,6 +12,7 @@
 
 -export([valid_peer_type/1, init/1, peer_flags/1, accept_peer/2, peer_ready/3,
          send/3, recv/2,
+         unblock/2,
          send_multipart/3, recv_multipart/2, peer_recv_message/3,
          queue_ready/3, peer_disconected/2, identity/1]).
 
@@ -77,6 +78,14 @@ recv_multipart(#chumak_router{recv_queue=RecvQueue, pending_recv=nil}=State, Fro
     end;
 recv_multipart(State, _From) ->
     {reply, {error, efsm}, State}.
+
+unblock(#chumak_router{pending_recv={from, PendingRecv}}=State, _From) ->
+    NewState = State#chumak_router{pending_recv=nil},
+    gen_server:reply(PendingRecv, {error, again}),
+    {reply, ok, NewState};
+
+unblock(#chumak_router{pending_recv=nil}=State, _From) ->
+    {reply, ok, State}.
 
 peer_recv_message(State, _Message, _From) ->
      %% This function will never called, because use incoming_queue property

--- a/src/chumak_xpub.erl
+++ b/src/chumak_xpub.erl
@@ -12,6 +12,7 @@
 -define(PUB, chumak_pub).
 -export([valid_peer_type/1, init/1, peer_flags/1, accept_peer/2, peer_ready/3,
          send/3, recv/2,
+         unblock/2,
          send_multipart/3, recv_multipart/2, peer_recv_message/3,
          queue_ready/3, peer_disconected/2, peer_subscribe/3, peer_cancel_subscribe/3,
          identity/1
@@ -29,6 +30,7 @@ send(State, Data, From) -> ?PUB:send(State, Data, From).
 recv(State, From) -> ?PUB:recv(State, From).
 send_multipart(State, Data, From) -> ?PUB:send_multipart(State, Data, From).
 recv_multipart(State, From) -> ?PUB:recv_multipart(State, From).
+unblock(State, From) -> ?PUB:unblock(State, From).
 peer_recv_message(State, Message, From) -> ?PUB:peer_recv_message(State, Message, From).
 queue_ready(State, Identity, From) -> ?PUB:queue_ready(State, Identity, From).
 peer_disconected(State, PeerPid) -> ?PUB:peer_disconected(State, PeerPid).


### PR DESCRIPTION
Thanks for your quick response last time!
As promised (see #31), here is `unblock` for the rest of the socket types.
I also ran dialyzer to not introduce any new type errors.
