### PR TITLE
Let non-Windows users specify other CURVE libraries

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -80,7 +80,7 @@ DetermineCurveDep =
                         undefined
                 end;
             _ ->
-                NaCerlDep
+                undefined
         end
     end,
 


### PR DESCRIPTION
Fixes #39.

CurveCompilerOption sets the definition for the CURVE library, but CurveDep still remains `undefined` when "nacerl" is not used.