### PR TITLE
Support "*" hostname to bind to all network interfaces

### DIFF
--- a/src/chumak_bind.erl
+++ b/src/chumak_bind.erl
@@ -12,7 +12,7 @@
 start_link(Host, Port) ->
     ParentPid = self(),
 
-    case inet:getaddr(Host, inet) of
+    case getaddr(Host) of
         {ok, Addr} ->
             case gen_tcp:listen(Port, ?SOCKET_OPTS([{ip, Addr}])) of
                 {ok, ListenSocket} ->
@@ -59,3 +59,11 @@ listener(ListenSocket, ParentPid) ->
                                       ]),
             listener(ListenSocket, ParentPid)
     end.
+
+-spec getaddr(Host::string()) -> {ok, inet:ip_address() | any} | {error, Reason::term()}.
+
+getaddr("*") ->
+    {ok, any};
+
+getaddr(Host) ->
+    inet:getaddr(Host, inet).


### PR DESCRIPTION
This PR adds the ability to listen on all interfaces.

`Addr` which is passed to `gen_tcp:listen` can be one of:
```
socket_address() = 
    ip_address() | any | loopback | local_address()
```

In this PR I'm converting "*" hostname to `any`, which is then passed to `gen_tcp:listen` and makes it to listen on all interfaces.

Example:

```
{ok, Socket} = chumak:socket(router),
{ok, Peer} = chumak:bind(Socket, tcp, "*", 4000)
```