### PR TITLE
Use project_plugins for rebar3_hex

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
 {erl_opts, [debug_info]}. 
-{plugins, [rebar3_hex]}.
+{project_plugins, [rebar3_hex]}.


### PR DESCRIPTION
This way, dependent projects don't need to install this one as well.