### PR TITLE
fix: return socket pid if already started

### DIFF
--- a/src/chumak_sup.erl
+++ b/src/chumak_sup.erl
@@ -34,6 +34,8 @@ start_socket(Type, Identity) ->
                             }) of
         {error, already_present} ->
             supervisor:restart_child(?MODULE, ProcessId);
+        {error, {already_started, Pid}} ->
+            {ok, Pid};
         Res ->
             Res
     end.

--- a/test/chumak_socket_test.erl
+++ b/test/chumak_socket_test.erl
@@ -9,3 +9,9 @@
 init_with_invalid_pattern_test() ->
     {stop, Reason} = chumak_socket:init({foo, "my-identity"}),
     ?assertEqual(Reason, invalid_socket_type).
+
+already_started_socket_test() ->
+    {ok, Pid1} = chumak:socket(dealer, "identity"),
+    {ok, Pid2} = chumak:socket(dealer, "identity"),
+    ?assertEqual(Pid1, Pid2),
+    ok.


### PR DESCRIPTION
When a socket with an identity is already started, the
`chumak:socket/2` function returns `{error, {already_stared, pid()}}`,
which is the return of `supervisor:start_child/2` for that case.  This
violates the typespec of `chumak:socket/2`.

This patch changes that to return the already started socket PID to
the caller.