### PR TITLE
Allow for use of custom pattern object + 2 small bug fixes

### DIFF
--- a/src/chumak.erl
+++ b/src/chumak.erl
@@ -38,7 +38,7 @@ stop(_State) ->
 
 
 %% @doc start a new socket
--spec socket(Type::socket_type(), Identity::string()) ->
+-spec socket(Type::socket_type() | atom(), Identity::string()) ->
                     {ok, SocketPid::pid()} | {error, Reason::atom()}.
 socket(Type, Identity)
   when is_atom(Type),

--- a/src/chumak_pattern.erl
+++ b/src/chumak_pattern.erl
@@ -11,7 +11,7 @@
 
 -export([module/1, error_msg/1]).
 
--type pattern_state() :: tuple().
+-type pattern_state() :: map().
 
 -callback valid_peer_type(SocketType::socket_type()) -> valid | invalid.
 -callback init(Identity::string()) -> {ok, pattern_state()}.

--- a/src/chumak_peer.erl
+++ b/src/chumak_peer.erl
@@ -282,6 +282,9 @@ negotiate_greetings(#state{socket=Socket,
         {ready, NewDecoder} = chumak_protocol:decode(State#state.decoder, GreetingFrame),
         verify_mechanism(State, NewDecoder)
     catch
+        error:{badmatch, {error, timeout}} ->
+            ?LOG_WARNING("zmq handshake timeout", #{error => negotiate_error, reason => timeout}),
+            {stop, {shutdown, timeout}, State};
         error:{badmatch, {error, Reason}} ->
             ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, reason => Reason}),
             {stop, {error, Reason}, State};

--- a/src/chumak_sup.erl
+++ b/src/chumak_sup.erl
@@ -24,7 +24,7 @@ start_link() ->
 init(_Args) ->
     {ok, {?SUPERVISOR_FLAGS, []}}.
 
--spec start_socket(Type::socket_type(), Identity::string()) -> {ok, SocketPid::pid()} | {error, Reason::atom()}.
+-spec start_socket(Type::socket_type() | atom(), Identity::string()) -> {ok, SocketPid::pid()} | {error, Reason::atom()}.
 start_socket(Type, Identity) ->
     ProcessId = get_child_id(Identity), %% generate an atom ?
     case supervisor:start_child(?MODULE, #{


### PR DESCRIPTION
This pull request extends chumak so that custom pattern object can be used in addition to predefined ones. This allows (for example) complex handling of connection and disconnection logic of peers or other non-standard scenarios.

Also if fixes 2 small bugs
- unhandled timeout error
- wrong type for pattern_state