### PR TITLE
Add actions for tests & coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       uses: erlef/setup-beam@v1
       with:
         otp-version: ${{matrix.otp_version}}
-        rebar3-version: '3.24.0'
+        rebar3-version: '3.22.1'
     
     - name: Install Dependencies
       run: |
@@ -44,7 +44,7 @@ jobs:
       run: rebar3 cover
     
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
         path: _build/test/cover/ 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,19 @@ name: Erlang CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "master" ]
+  workflow_dispatch:
 
 jobs:
   build:
     name: Test on OTP ${{matrix.otp_version}}
     runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      pull-requests: write
     
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Erlang CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Test on OTP ${{matrix.otp_version}}
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        otp_version: ['24.3', '25.3', '26.2', '27.2']
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup Erlang
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{matrix.otp_version}}
+        rebar3-version: '3.24.0'
+    
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc make
+    
+    - name: Compile
+      run: rebar3 compile
+    
+    - name: Run tests
+      run: rebar3 eunit -c
+    
+    - name: Generate coverage report
+      run: rebar3 cover
+    
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: code-coverage-report
+        path: _build/test/cover/ 


### PR DESCRIPTION
This PR attempts to start a history of test status and coverage.  I've chosen to test against the past 4 versions of OTP, but this might be overdoing it. 

The tests are not all passing on my machine, so if GitHub CI agrees with this, then a following PR will fix tests.

Keeping in draft until CI is shown to be accurate.

Note: A maintainer will need to approve this workflow, see **1 workflow awaiting approval** below.