### PR TITLE
Log remote address on handshake errors

### DIFF
--- a/src/chumak_curve.erl
+++ b/src/chumak_curve.erl
@@ -80,10 +80,10 @@ security_handshake(Socket, Decoder, false, Metadata) ->
         {Decoder5, {ready, MetaData#{security_data => CurveData6}}}
     catch
         error:{badmatch, {error, Reason}} ->
-            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, reason => Reason}),
+            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, peer => inet:peername(Socket), reason => Reason}),
             {Decoder, {error, Reason}};
         error:{badmatch, Error} ->
-            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, reason => Error}),
+            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, peer => inet:peername(Socket), reason => Error}),
             {Decoder, {error, Error}}
     end;
 security_handshake(Socket, Decoder, true, Metadata) ->
@@ -131,10 +131,10 @@ security_handshake(Socket, Decoder, true, Metadata) ->
         {Decoder6, {ready, MetaData#{security_data => CurveData6}}}
     catch
         error:{badmatch, {error, Reason}} ->
-            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, reason => Reason}),
+            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, peer => inet:peername(Socket), reason => Reason}),
             {Decoder, {error, Reason}};
         error:{badmatch, Error} ->
-            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, reason => Error}),
+            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, peer => inet:peername(Socket), reason => Error}),
             {Decoder, {error, Error}}
     end.
 

--- a/src/chumak_peer.erl
+++ b/src/chumak_peer.erl
@@ -286,10 +286,10 @@ negotiate_greetings(#state{socket=Socket,
             ?LOG_WARNING("zmq handshake timeout", #{error => negotiate_error, reason => timeout}),
             {stop, {shutdown, timeout}, State};
         error:{badmatch, {error, Reason}} ->
-            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, reason => Reason}),
+            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, peer => inet:peername(Socket), reason => Reason}),
             {stop, {error, Reason}, State};
         error:{badmatch, Error} ->
-            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, reason => Error}),
+            ?LOG_ERROR("zmq handshake error", #{error => negotiate_error, peer => inet:peername(Socket), reason => Error}),
             {stop, Error, State}
     end.
 


### PR DESCRIPTION
If something tries to speak HTTP or something to a ZMQ socket, chumak fills the logs with the `bad_greeting_frame` error which tells us _what_ was transmitted, but not _who_ transmitted it. Once more than a few possible machines are in the picture, it becomes very hard to figure out what is actually happening.

This change uses `inet:peername` to get a human-readable remote IP address to be added to the logged error's metadata.